### PR TITLE
fixed AuthProviders to use authenticity_token from sign in page

### DIFF
--- a/src/AuthProviderCombined.php
+++ b/src/AuthProviderCombined.php
@@ -168,6 +168,11 @@ class AuthProviderCombined implements AuthProvider {
         // prepare curl request
         if($this->_session == "" || !file_exists($this->_session)) {    //login for new session
             $req = curl_init('https://auth.aiesec.org/users/sign_in');
+            curl_setopt($req, CURLOPT_RETURNTRANSFER, 1);
+            preg_match( '/<meta.*content="(.*)".*name="csrf-token"/', curl_exec($req), $match );
+            $data .= "&authenticity_token=" . urlencode($match[1]);
+            
+            $req = curl_init('https://auth.aiesec.org/users/sign_in');
             curl_setopt($req, CURLOPT_POST, true);
             curl_setopt($req, CURLOPT_POSTFIELDS, $data);
         } else {    // request EXPA token for existing session

--- a/src/AuthProviderEXPA.php
+++ b/src/AuthProviderEXPA.php
@@ -127,6 +127,11 @@ class AuthProviderEXPA implements AuthProvider {
         // initiate curl request
         if($this->_session == "" || !file_exists($this->_session)) {    // to perform login if there is no session
             $req = curl_init('https://auth.aiesec.org/users/sign_in');
+            curl_setopt($req, CURLOPT_RETURNTRANSFER, 1);
+            preg_match( '/<meta.*content="(.*)".*name="csrf-token"/', curl_exec($req), $match );
+            $data .= "&authenticity_token=" . urlencode($match[1]);
+
+            $req = curl_init('https://auth.aiesec.org/users/sign_in');
             curl_setopt($req, CURLOPT_POST, true);
             curl_setopt($req, CURLOPT_POSTFIELDS, $data);
         } else {    // to request EXPA token if there is a session


### PR DESCRIPTION
@kjschubert please have a look, if this is the best possible way to fix it.
The authenticity_token from the sign up page is now enforced, so you have to get it first. But I was just looking for a quick fix. maybe there is a better coding style to achieve this.